### PR TITLE
Add api get balance

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -77,13 +77,13 @@ func main() {
 		RedirectURI:  cfg.OauthClient.RedirectURI,
 	}
 	assetService := service.NewAssetService(chainRepo, tokenRepo, redisClient)
-	walletService := service.NewWalletService(walletRepo, tssClient)
+	walletService := service.NewWalletService(walletRepo, tssClient, ethClient)
 	userService := service.NewUserService(userRepo, walletRepo, redisClient)
 	authService := service.NewAuthService(userService, walletService, tokenManager, oauthClient)
 	transactionService := service.NewTransactionService(transactionRepo, walletService, assetService, ethClient, tssClient)
 
 	// router
-	router := api.NewRouter(authService, assetService, userService, transactionService, tokenManager)
+	router := api.NewRouter(authService, assetService, userService, transactionService, tokenManager, walletService)
 
 	// run router
 	logger.Info("Running router")

--- a/backend/internal/api/handler/transaction.go
+++ b/backend/internal/api/handler/transaction.go
@@ -76,6 +76,7 @@ func (h *TransactionHandler) CreateAndSubmitTransaction(c *gin.Context) {
 		c.Error(err)
 		return
 	}
+	logger.Debug("CreateAndSubmitTransaction request")
 
 	res, err := h.txnService.CreateAndSubmitTransaction(c.Request.Context(), userID, req)
 	if err != nil {

--- a/backend/internal/api/handler/wallet.go
+++ b/backend/internal/api/handler/wallet.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"mpc/internal/model"
+	"mpc/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+type WalletHandler struct {
+	BaseHandler
+	walletService *service.WalletService
+}
+
+func NewWalletHandler(walletService *service.WalletService) *WalletHandler {
+	return &WalletHandler{
+		BaseHandler:   NewBaseHandler(),
+		walletService: walletService,
+	}
+}
+
+// GetBalance godoc
+// @Summary      Get wallet balance
+// @Description  Get wallet balance
+// @Tags         wallets
+// @Accept       json
+// @Produce      json
+// @Success      200  {object}  model.Response{payload=model.WalletResponse}
+// @Failure      400  {object}  model.ErrorResponse
+// @Failure      401  {object}  model.ErrorResponse
+// @Router       /wallet [get]
+func (h *WalletHandler) GetBalance(c *gin.Context) {
+	userID, err := h.GetUserID(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	var req model.GetBalanceRequest
+	res, err := h.walletService.GetBalanceByAddress(c.Request.Context(), req, userID)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	h.SuccessResponse(c, res)
+}

--- a/backend/internal/api/middleware/cors.go
+++ b/backend/internal/api/middleware/cors.go
@@ -16,7 +16,31 @@ type CorsConfig struct {
 // DefaultCorsConfig returns the default CORS configuration
 func DefaultCorsConfig() CorsConfig {
 	return CorsConfig{
-		AllowOrigins: []string{"*"},
+		// AllowOrigins: []string{"*"},
+		// AllowMethods: []string{
+		// 	"GET",
+		// 	"POST",
+		// 	"PUT",
+		// 	"PATCH",
+		// 	"DELETE",
+		// 	"OPTIONS",
+		// },
+		// AllowHeaders: []string{
+		// 	"Origin",
+		// 	"Content-Type",
+		// 	"Content-Length",
+		// 	"Accept-Encoding",
+		// 	"X-CSRF-Token",
+		// 	"Authorization",
+		// 	"Accept",
+		// 	"Cache-Control",
+		// 	"X-Requested-With",
+		// },
+		// ExposeHeaders:    []string{"Content-Length"},
+		// AllowCredentials: true,
+
+		// for development purposes, allow origins from localhost
+		AllowOrigins: []string{"http://localhost:5173"},
 		AllowMethods: []string{
 			"GET",
 			"POST",
@@ -62,7 +86,9 @@ func CorsWithConfig(config CorsConfig) gin.HandlerFunc {
 		}
 
 		// Set other headers
-		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		if config.AllowCredentials {
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
 		c.Writer.Header().Set("Access-Control-Allow-Methods",
 			joinStrings(config.AllowMethods))
 		c.Writer.Header().Set("Access-Control-Allow-Headers",

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -19,6 +19,7 @@ func NewRouter(
 	userService *service.UserService,
 	txnService *service.TransactionService,
 	tokenManager *token.TokenManager,
+	walletService *service.WalletService,
 ) *gin.Engine {
 	// Disable default logger
 	gin.SetMode(gin.ReleaseMode)
@@ -37,6 +38,7 @@ func NewRouter(
 	assetHandler := handler.NewAssetHandler(assetService)
 	userHandler := handler.NewUserHandler(userService)
 	txnHandler := handler.NewTransactionHandler(txnService)
+	walletHandler := handler.NewWalletHandler(walletService)
 
 	v1 := router.Group("/api/v1")
 	{
@@ -68,6 +70,12 @@ func NewRouter(
 		{
 			transactions.GET("", txnHandler.GetTransactions)
 			transactions.POST("/", txnHandler.CreateAndSubmitTransaction)
+		}
+
+		wallet := v1.Group("/wallets")
+		wallet.Use(middleware.AuthMiddleware(tokenManager))
+		{
+			wallet.GET("/balance", walletHandler.GetBalance)
 		}
 
 		// Redirect to swagger docs

--- a/backend/internal/config/db.go
+++ b/backend/internal/config/db.go
@@ -5,5 +5,5 @@ type DBConfig struct {
 	Port     string `env:"DB_PORT" envDefault:"5432"`
 	User     string `env:"DB_USER" envDefault:"tinh"`
 	Password string `env:"DB_PASSWORD" envDefault:"123"`
-	DBName   string `env:"DB_NAME" envDefault:"mpcdev_2"`
+	DBName   string `env:"DB_NAME" envDefault:"mpc_key"`
 }

--- a/backend/internal/model/wallet.go
+++ b/backend/internal/model/wallet.go
@@ -23,3 +23,12 @@ type WalletResponse struct {
 	Address string    `json:"address" example:"0x0000000000000000000000000000000000000000"`
 	Name    string    `json:"name" example:"My Wallet"`
 }
+
+type GetBalanceRequest struct {
+	Address string `json:"address" validate:"required"`
+}
+
+type GetBalanceResponse struct {
+	Address string `json:"address" validate:"required"`
+	Balance string `json:"balance" validate:"required"` // Balance in wei
+}

--- a/backend/pkg/ethereum/eth.go
+++ b/backend/pkg/ethereum/eth.go
@@ -78,6 +78,23 @@ func (c *EthClient) IsEnoughBalance(ctx context.Context, address string, amount 
 	return balance.Cmp(amountWei) >= 0, nil
 }
 
+func (c *EthClient) GetBalance(ctx context.Context, address string) (string, error) {
+	if !common.IsHexAddress(address) {
+		return "", fmt.Errorf("invalid address: %s", address)
+	}
+	addr := common.HexToAddress(address)
+	balance, err := c.client.BalanceAt(ctx, addr, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch balance: %w", err)
+	}
+
+	ethValue := new(big.Float).Quo(new(big.Float).SetInt(balance), big.NewFloat(1e18))
+
+	strethValue := ethValue.Text('f', 18)
+
+	return strethValue, nil
+}
+
 // validateTransactionInputs checks the recipient address and converts the amount to Wei
 func (c *EthClient) validateTransactionInputs(address string, amount string) (common.Address, *big.Int, error) {
 	if !common.IsHexAddress(address) {

--- a/backend/pkg/tss/tss.go
+++ b/backend/pkg/tss/tss.go
@@ -78,6 +78,7 @@ func (t *TSS) CreateWallet(ctx context.Context, sessionID string) (shareData str
 
 	// Wait for results with timeout
 	shareData, publicKey, err = processKeygenResult(ctx, pubsub.Channel())
+	// logger.Debug(fmt.Sprintf("Keygen result received: shareData=%s, publicKey=%s", shareData, publicKey))
 	if err != nil {
 		return "", "", fmt.Errorf("key generation failed: %w", err)
 	}


### PR DESCRIPTION
### Mục tiêu
- Thêm API lấy số dư (balance)
- Bật CORS để hỗ trợ frontend kết nối từ localhost

### Chi tiết
- Thêm route `/api/v1/wallets/balance` trong backend
- Cập nhật cấu hình CORS để chấp nhận `http://localhost:5173`